### PR TITLE
Removed cached thread pool creation

### DIFF
--- a/src/main/java/com/coreoz/wisp/Scheduler.java
+++ b/src/main/java/com/coreoz/wisp/Scheduler.java
@@ -105,7 +105,6 @@ public final class Scheduler {
 		this.timeProvider = config.getTimeProvider();
 		this.launcherNotifier = new AtomicBoolean(true);
 		this.cancelHandles = new ConcurrentHashMap<>();
-		Executors.newCachedThreadPool(new WispThreadFactory());
 		this.threadPoolExecutor = new ScalingThreadPoolExecutor(
 			config.getMinThreads(),
 			config.getMaxThreads(),


### PR DESCRIPTION
Seems redundant and nobody uses the value of `Executors.newCachedThreadPool`, unless I'm missing something.